### PR TITLE
Display updates

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -223,7 +223,7 @@ void printBetMenu(WINDOW *menu, int numChoices, int bet, int highlight)
     wrefresh(menu);
 }
 
-void statsWindow(int money, int bet, int handValue, char *message)
+void statsWindow(int money, int bet, int handValue, int dealerHandValue, char *message)
 {
     WINDOW *statsWindow;
     int width = COLS/4;
@@ -237,7 +237,10 @@ void statsWindow(int money, int bet, int handValue, char *message)
     mvwprintw(statsWindow, 2 , 2, "Bet = %d", bet);
 
     if(handValue > 0)
-        mvwprintw(statsWindow, 3 , 2, "Hand = %d", handValue);
+        mvwprintw(statsWindow, 3 , 2, "Your Hand = %d", handValue);
+
+    if(dealerHandValue > 0)
+        mvwprintw(statsWindow, 4 , 2, "Dealer Hand = %d", dealerHandValue);
 
     if(message != ""){
         wattron(statsWindow, A_REVERSE);
@@ -478,7 +481,6 @@ int menuLoop()
     }
 
     return choice;
-
 }
 
 WINDOW *create_win(int height, int width, int starty, int startx)

--- a/src/display.c
+++ b/src/display.c
@@ -249,30 +249,72 @@ void statsWindow(int money, int bet, int handValue, char *message)
     delwin(statsWindow);
 }
 
-void alert(char *message)
+/*
+    Prints an alert message with an 'OK' message to the screen.
+    If the length of the message exceeds the bounds determined by the size of
+    the alert box, then a single question mark is displayed in the box.
+
+    Max length that can fit in the box is determined by the expression:
+        (width - (X_MARGIN * 2)) * (height - ((Y_MARGIN + 1) * 2))
+    
+    Then, Max length of one line can be determined by the expression:
+        width - (X_MARGIN * 2)
+
+    Text that does not fit on one line will be word-wrapped without hypenation
+*/
+void alert(char *message, int height, int width, int startY, int startX)
 {
     WINDOW *alertBox;
 
-    int height = 7;
-    int width = 16;
-    int starty = TITLE_LINES + TITLE_INDENT;
-    int startx = (COLS - width) / 2;
-
-    int yMargin = 2;  
-
-    alertBox = create_win(height, width, starty, startx);
+    alertBox = create_win(height, width, startY, startX);
     keypad(alertBox, TRUE);
 
-    mvwprintw(alertBox, yMargin, (width/2) - (strlen(message))/2, message);
-
+    if(strlen(message) < width - (X_MARGIN) * 2){
+        mvwprintw(alertBox, Y_MARGIN, (width/2) - (strlen(message))/2, message);
+    }
+    else if(strlen(message) < (width - (X_MARGIN * 2)) * (height - ((Y_MARGIN + 1) * 2))){
+        centerJustifyPrint(alertBox, message, width - (X_MARGIN * 2));
+    }
+    else {
+        mvwprintw(alertBox, Y_MARGIN, width/2, "?");
+    }
+    
     wattron(alertBox, A_REVERSE);
-    mvwprintw(alertBox, height - 2, (width/2) - 1, "OK");
+    mvwprintw(alertBox, height - (Y_MARGIN + 1), (width/X_MARGIN) - 1, "OK");
     wattroff(alertBox, A_REVERSE);
 
     wrefresh(alertBox);
 
     if(wgetch(alertBox))
-        destroy_win(alertBox);
+        wclear(alertBox);
+}
+
+
+/* 
+    Prints characters to a given window, centering text when possible.
+    Does not hyphenate words that exceed length of line
+*/
+void centerJustifyPrint(WINDOW *window, char *string, int maxLineChars) {
+    int charsLeft = (strlen(string)); 
+
+    int row = Y_MARGIN;
+    int col = X_MARGIN;
+
+    for(int i = 0; string[i] != 0; i++){
+        if(col == maxLineChars + X_MARGIN){
+            if(charsLeft < maxLineChars){
+                col = X_MARGIN + (maxLineChars - charsLeft) / 2;
+            }
+            else {
+                col = X_MARGIN;
+            }
+            
+            row += 1;
+        }
+        mvwaddch(window, row, col, string[i]);
+        charsLeft -= 1;
+        col += 1;
+    }
 }
 
 // 1 2 3 4 5 6 7 8 9 10 11 12 13
@@ -320,13 +362,13 @@ void printCard(char suit, int value, int cardCount, bool hideFirstCard, bool isD
     wrefresh(card);
 }
 
-void printTitle(MEVENT *event)
+// Prints a bordered title screen
+void printTitle()
 {
     WINDOW *titleScreen;
     int startx = 0;
 
     titleScreen = create_win(LINES, COLS, 0, 0);
-    keypad(titleScreen, TRUE);
 
     for(int i = 0; i < (sizeof(Title)/sizeof(Title[0])); i++){
         startx = (COLS / 2) - (strlen(Title[i]) / 2);
@@ -334,25 +376,20 @@ void printTitle(MEVENT *event)
     }
 
     wrefresh(titleScreen);
-
-    /* Remain on title screen until key is pressed */
-    if(wgetch(titleScreen) || getmouse(event) == OK);
-        destroy_win(titleScreen);
 }
 
 void printMenu(WINDOW *menu, int numChoices, int highlight, char *choices[])
 {
-    int xMargin = 2;
-    int yMargin = 2;
+    int yMargin = Y_MARGIN;
 
     for(int i = 0; i < numChoices; i++){
         if(highlight == i + 1){
             wattron(menu, A_REVERSE);
-            mvwprintw(menu, yMargin, xMargin, "%s", choices[i]);
+            mvwprintw(menu, yMargin, X_MARGIN, "%s", choices[i]);
             wattroff(menu, A_REVERSE);
         }
         else
-            mvwprintw(menu, yMargin, xMargin, "%s", choices[i]);
+            mvwprintw(menu, yMargin, X_MARGIN, "%s", choices[i]);
         
         ++yMargin;
     }

--- a/src/game.c
+++ b/src/game.c
@@ -34,7 +34,7 @@ void gameLoop(pcg32_random_t *randSeed)
 
         vegasShuffle(deckPtr, randSeed);
         gameBoard(dealer.limit);
-        statsWindow(player.money, bet, 0, "");
+        statsWindow(player.money, bet, 0, 0, "");
         gameChoice = gameMenuLoop();
         switch(gameChoice)
         {
@@ -48,7 +48,7 @@ void gameLoop(pcg32_random_t *randSeed)
             printHand(dealer.hand, true, true);
             printHand(player.hand, false, false);
 
-            statsWindow(player.money, bet, sumHand(player.hand), "");
+            statsWindow(player.money, bet, sumHand(player.hand), sumObscuredHand(dealer.hand), "");
 
             subGameInPlay = true;
 
@@ -59,10 +59,10 @@ void gameLoop(pcg32_random_t *randSeed)
                 case HIT:
                     appendCard(deckPtr, player.hand);
                     printHand(player.hand, false, false);
-                    statsWindow(player.money, bet, sumHand(player.hand), "");
+                    statsWindow(player.money, bet, sumHand(player.hand), sumObscuredHand(dealer.hand), "");
                     if(sumHand(player.hand) > 21){
-                        statsWindow(player.money, bet, sumHand(player.hand), "BUST");
                         dealerTurn(dealer.limit, dealer.hand, deckPtr);
+                        statsWindow(player.money, bet, sumHand(player.hand), sumHand(dealer.hand), "BUST");
                         closeBets(checkResult(dealer.hand, player.hand), bet, &dealer, &player);
                         delHand(dealer.hand, player.hand, deckPtr);
                         subGameInPlay = false;
@@ -75,16 +75,17 @@ void gameLoop(pcg32_random_t *randSeed)
                         appendCard(deckPtr, player.hand);
                         printHand(player.hand, false, false);
                         dealerTurn(dealer.limit, dealer.hand, deckPtr);
-                        statsWindow(player.money, bet, sumHand(player.hand), "");
+                        statsWindow(player.money, bet, sumHand(player.hand), sumHand(dealer.hand), "");
                     }
                     else{
-                        statsWindow(player.money, bet, sumHand(player.hand), "Not enough money");
+                        statsWindow(player.money, bet, sumHand(player.hand), sumObscuredHand(dealer.hand), "Not enough money");
                         alert("Can't do that", 7, 16, LINES/2, COLS/2);
                     }
                     break;
 
                 case STAND:
                     dealerTurn(dealer.limit, dealer.hand, deckPtr);
+                    statsWindow(player.money, bet, sumHand(player.hand), sumHand(dealer.hand), "");
                     break;
 
                 case FOLD:
@@ -230,6 +231,41 @@ int sumHand(struct Hand *hand)
 
     int sum = 0;
     struct Hand *temp = hand;
+
+    while(temp != NULL){
+        if(temp->card.value < 9)
+            sum += temp->card.value + 1;
+        else if(temp->card.value > 8 && temp->card.value < 13)
+            sum += 10;
+        else{
+            if((sum + 11) <= 21)
+                sum += 11;
+            else
+                sum += 1;
+        }
+
+        temp = temp->next;
+    }
+
+
+    return sum;
+}
+
+int sumObscuredHand(struct Hand *hand)
+{
+    if(hand == NULL)
+        return -1;
+
+    int sum = 0;
+    struct Hand *temp = hand;
+
+    // Skip first/hidden card
+    if(temp->next != NULL) {
+        temp = temp->next;
+    }
+    else {
+        return -1;
+    }
 
     while(temp != NULL){
         if(temp->card.value < 9)

--- a/src/game.c
+++ b/src/game.c
@@ -79,7 +79,7 @@ void gameLoop(pcg32_random_t *randSeed)
                     }
                     else{
                         statsWindow(player.money, bet, sumHand(player.hand), "Not enough money");
-                        alert("Can't do that");
+                        alert("Can't do that", 7, 16, LINES/2, COLS/2);
                     }
                     break;
 

--- a/src/include/display.h
+++ b/src/include/display.h
@@ -14,7 +14,6 @@
 
 // ASCII Art generated on https://www.patorjk.com/software/taag/
 // Using the font DOOM by Frans P. de Vries <fpv@xymph.iaf.nl>  18 Jun 1996
-// TODO: Find a better way to display the title
 static char const *Title[] = {
     "_____                       ___            _",
     "/  __ \\                     |_  |          | |",
@@ -34,7 +33,7 @@ static char *MenuChoices[] = {
     "Start",
     "Options",
     "Load Save",
-    "Close",
+    "End",
 };
 
 static char *GameMenuChoices[] = {
@@ -69,11 +68,13 @@ int betMenu(int currentBet, int highlight);
 
 void statsWindow(int money, int bet, int handValue, char *message);
 
-void alert(char *message);
+void alert(char *message, int height, int width, int startY, int startX);
+
+void centerJustifyPrint(WINDOW *window, char *string, int maxLineChars);
 
 void printCard(char suit, int value, int cardCount, bool hideFirstCard, bool isDealer);
 
-void printTitle(MEVENT *event);
+void printTitle();
 
 void printMenu(WINDOW *menu, int numChoices, int highlight, char *choices[]);
 

--- a/src/include/display.h
+++ b/src/include/display.h
@@ -66,7 +66,7 @@ int inGameMenuLoop();
 
 int betMenu(int currentBet, int highlight);
 
-void statsWindow(int money, int bet, int handValue, char *message);
+void statsWindow(int money, int bet, int handValue, int dealerHandValue, char *message);
 
 void alert(char *message, int height, int width, int startY, int startX);
 

--- a/src/include/game.h
+++ b/src/include/game.h
@@ -39,6 +39,8 @@ void closeBets(int result, int bet, struct Dealer *dealer, struct Player *player
 
 int sumHand(struct Hand *hand);
 
+int sumObscuredHand(struct Hand *hand);
+
 void delHand(struct Hand *dealerHand, struct Hand *playerHand, struct Card *deckPtr);
 
 //void initHead(struct Card *deckPtr, struct Hand *hand);

--- a/src/main.c
+++ b/src/main.c
@@ -14,16 +14,15 @@ int main(int argc, char *argv[])
     pcg32_random_t rng;
     pcg32_srandom_r(&rng, time(NULL) ^ (intptr_t)&printf, (intptr_t)&printTitle);
 
-    MEVENT event;
-    int choice = 0;
-
     // This must go near the start, else we cannot obtain LINES or COLS
     initCurses();
     
-    printTitle(&event);
-    
-    while(1)
+    int choice = 0;
+
+    while(choice != QUIT)
     {
+        refresh();
+        printTitle();
         choice = menuLoop();
         switch(choice)
         {
@@ -31,19 +30,15 @@ int main(int argc, char *argv[])
                 gameLoop(&rng);
                 break;
             case OPTIONS:
-                mvprintw(2, 1, "Choice %d has not been implemented", choice);
-                refresh();
+                alert("OPTIONS has not been implemented yet", 8, 30, TITLE_LINES + TITLE_INDENT, (COLS - 30) / 2);
                 break;
             case LOAD:
-                mvprintw(2, 1, "Choice %d has not been implemented", choice);
-                refresh();
+                alert("LOAD has not been implemented yet", 8, 30, TITLE_LINES + TITLE_INDENT, (COLS - 30) / 2);
                 break;
             case QUIT:
-                endwin();
-                return 0;
+                break;
             default:
-                mvprintw(2, 1, "Choice %d is undefined", choice);
-                refresh();
+                alert("That choice has not been implemented yet", 8, 30, TITLE_LINES + TITLE_INDENT, (COLS - 30) / 2);
                 break;
         }
     }


### PR DESCRIPTION
Updated display functions to resolve the following issues:
- Keep title screen border when displaying start menu
- Fix top padding for game menus
- Added displays for alert box windows
- Center justify text in alert boxes and start menu
- Re-display title screen when exiting game board window
- Display dealer's current visible hand